### PR TITLE
Added option top overwrite the default classes globally

### DIFF
--- a/src/quick-edit.vue
+++ b/src/quick-edit.vue
@@ -1,3 +1,4 @@
+/* global QUICKEDIT_DEFAULT_CLASSES */
 <template>
   <div ref="el" :class="classNames.wrapper">
     <template v-if="isEditing && isEnabled">
@@ -324,6 +325,12 @@ export default {
   },
   created() {
     this.setValue(this.value);
+  },
+  mounted() {
+    // Checks if the defaults need to be replaced by a custom definition in runtime.
+    if (typeof window.QUICKEDIT_DEFAULT_CLASSES !== 'undefined') {
+      this.defaultClasses = Object.assign({}, this.defaultClasses, window.QUICKEDIT_DEFAULT_CLASSES);
+    }
   },
 };
 </script>


### PR DESCRIPTION
This helps me when I need to have multiple quickedit elements on the page and want to be able to do 2 things:
- Not having to pass a classes element to each component
- When using the component without compiling Vue, so that these can be defined on a runtime level.